### PR TITLE
1week

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
-application.yml
-
 ### STS ###
 .apt_generated
 .classpath
@@ -37,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Custom ###
+application-secret.yml

--- a/records/1Week_KimDoWon.md
+++ b/records/1Week_KimDoWon.md
@@ -1,0 +1,47 @@
+## Title: [1Week] 김도원
+
+### 미션 요구사항 분석 & 체크리스트
+
+---
+- [x] 호감상대 삭제 기능 구현
+    - [x] url의 `[likeablePerson.id](http://likeablePerson.id)` 와 일치하는 데이터를 DB에서 삭제
+    - [x] 삭제 권한 체크 (본인이 등록한 호감상대만 삭제 가능)
+    - [x] 삭제 후 다시 호감목록 페이지로 이동 (rq.redirectWithMsg 함수 사용)
+    - [x] 삭제 버튼 style 적용
+
+- 테스트케이스 작성
+    - [ ] 호감상대 추가
+    - [ ] 호감상대 삭제
+
+
+### 1주차 미션 요약
+
+---
+
+**[접근 방법]**
+
+- `호감상대 삭제 = DB에서 LikeablePerson 테이블의 row 하나를 삭제하는 것` 에 중점을 두고 구현하였습니다.
+- 미션 진행하기 전 실습했던 <점프 투 스프링부트> 책과 gramgram 프로젝트를 참고하였습니다.
+
+- 목표: 삭제권한 체크 후 삭제처리 & 확인창 보여주기
+
+1. 호감상대 삭제 기능 구현
+- @GetMapping 어노테이션을 사용하여 LikeablePersonController의 delete() 메서드를 list.html에서 요청된 URL과 매핑
+- 요청된 URL에서 `[likeablePerson.id](http://likeablePerson.id)` 는 Controller의 매개변수로 받을 때 likeablePerson. 없이 id만 작성해야 함
+    - 그렇지 않으면 오류발생
+- 매개변수 id와 일치하는 likeablePerson 객체 가져오기
+    - 객체를 쉽게 가져오기 위해 `likeablePersonService에 getLikeablePerson`() 메서드 구현
+- rq의 getMember() 메서드를 사용하여 현재 로그인한 Member의 객체를 가져와서 likeablePerson 객체 안의 FromInstaMember의 id와 일치하는지 확인하기
+- `rq.redirectWithMsg()`를 활용하여 메세지 출력하고 호감목록으로 이동하기
+
+2. 테스트케이스 작성
+- MockMvc 클래스와 resultActions 클래스 등을 다루는 것이 어려워 미완료
+
+
+**[특이사항]**
+
+- 삭제 권한 체크하는 코드에서 if문의 조건식을 잘못 작성하였을 때, 호감표시와 호감목록에 접속이 안되는 오류가 발생하였습니다.
+    - 호감표시와 관련된 코드가 없는데 왜 호감표시까지 오류발생하는지 궁금합니다.
+
+**Refactoring**
+- 삭제 완료 후 뜨는 확인창 표시시간 줄이기

--- a/records/1Week_KimDoWon.md
+++ b/records/1Week_KimDoWon.md
@@ -9,8 +9,7 @@
     - [x] 삭제 후 다시 호감목록 페이지로 이동 (rq.redirectWithMsg 함수 사용)
     - [x] 삭제 버튼 style 적용
 
-- 테스트케이스 작성
-    - [ ] 호감상대 추가
+- [ ] 테스트케이스 작성
     - [ ] 호감상대 삭제
 
 
@@ -25,6 +24,7 @@
 
 - 목표: 삭제권한 체크 후 삭제처리 & 확인창 보여주기
 
+
 1. 호감상대 삭제 기능 구현
 - @GetMapping 어노테이션을 사용하여 LikeablePersonController의 delete() 메서드를 list.html에서 요청된 URL과 매핑
 - 요청된 URL에서 `[likeablePerson.id](http://likeablePerson.id)` 는 Controller의 매개변수로 받을 때 likeablePerson. 없이 id만 작성해야 함
@@ -34,14 +34,15 @@
 - rq의 getMember() 메서드를 사용하여 현재 로그인한 Member의 객체를 가져와서 likeablePerson 객체 안의 FromInstaMember의 id와 일치하는지 확인하기
 - `rq.redirectWithMsg()`를 활용하여 메세지 출력하고 호감목록으로 이동하기
 
+
 2. 테스트케이스 작성
 - MockMvc 클래스와 resultActions 클래스 등을 다루는 것이 어려워 미완료
 
 
 **[특이사항]**
 
-- 삭제 권한 체크하는 코드에서 if문의 조건식을 잘못 작성하였을 때, 호감표시와 호감목록에 접속이 안되는 오류가 발생하였습니다.
-    - 호감표시와 관련된 코드가 없는데 왜 호감표시까지 오류발생하는지 궁금합니다.
+- test에 .param 입력하는 것이 어려움
 
-**Refactoring**
+
+**[Refactoring]**
 - 삭제 완료 후 뜨는 확인창 표시시간 줄이기

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -26,6 +26,7 @@ public class NotProd {
             Member memberUser4 = memberService.join("user4", "1234").getData();
 
             Member memberUser5ByKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__2735734217").getData();
+            Member memberUser6ByGoogle = memberService.whenSocialLogin("GOOGLE", "GOOGLE__110608893721110296238").getData();
 
             instaMemberService.connect(memberUser2, "insta_user2", "M");
             instaMemberService.connect(memberUser3, "insta_user3", "W");

--- a/src/main/java/com/ll/gramgram/base/rq/Rq.java
+++ b/src/main/java/com/ll/gramgram/base/rq/Rq.java
@@ -69,6 +69,9 @@ public class Rq {
         String key = "historyBackErrorMsg___" + referer;
         req.setAttribute("localStorageKeyAboutHistoryBackErrorMsg", key);
         req.setAttribute("historyBackErrorMsg", msg);
+
+        // 200이 아니라 400으로 응답코드가 지정되도록
+        resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
         return "common/js";
     }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
@@ -40,4 +40,18 @@ public class InstaMember {
     @LazyCollection(LazyCollectionOption.EXTRA) // fromLikeablePeople의 size를 구할 때 count() 실행
     @Builder.Default // @Builder 가 있으면 `= new ArrayList<>();` 가 작동하지 않는다. 그래서 이걸 붙여야 한다.
     private List<LikeablePerson> fromLikeablePeople = new ArrayList<>();
+
+    @OneToMany(mappedBy = "toInstaMember", cascade = {CascadeType.ALL})
+    @OrderBy("id desc") // 정렬
+    @LazyCollection(LazyCollectionOption.EXTRA)
+    @Builder.Default // @Builder 가 있으면 ` = new ArrayList<>();` 가 작동하지 않는다. 그래서 이걸 붙여야 한다.
+    private List<LikeablePerson> toLikeablePeople = new ArrayList<>();
+
+    public void addFromLikeablePerson(LikeablePerson likeablePerson) {
+        fromLikeablePeople.add(0, likeablePerson);
+    }
+
+    public void addToLikeablePerson(LikeablePerson likeablePerson) {
+        toLikeablePeople.add(0, likeablePerson);
+    }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
@@ -1,12 +1,17 @@
 package com.ll.gramgram.boundedContext.instaMember.entity;
 
+import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
@@ -29,4 +34,10 @@ public class InstaMember {
     private String username;
     @Setter
     private String gender;
+
+    @OneToMany(mappedBy = "fromInstaMember", cascade = {CascadeType.ALL}) // LikeablePerson 엔티티에서 InstaMember 엔티티를 참조한 속성명 fromInstaMember
+    @OrderBy("id desc") // 정렬 (LikeablePerson의 id)
+    @LazyCollection(LazyCollectionOption.EXTRA) // fromLikeablePeople의 size를 구할 때 count() 실행
+    @Builder.Default // @Builder 가 있으면 `= new ArrayList<>();` 가 작동하지 않는다. 그래서 이걸 붙여야 한다.
+    private List<LikeablePerson> fromLikeablePeople = new ArrayList<>();
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -66,7 +66,7 @@ public class LikeablePersonController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @GetMapping("/delete/{id}")
+    @PostMapping("/delete/{id}")
     public String delete(@PathVariable Long id) {
         LikeablePerson likeablePerson = likeablePersonService.findById(id).orElse(null);
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -12,10 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -66,7 +63,7 @@ public class LikeablePersonController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @PostMapping("/delete/{id}")
+    @DeleteMapping("/{id}")
     public String delete(@PathVariable Long id) {
         LikeablePerson likeablePerson = likeablePersonService.findById(id).orElse(null);
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -55,7 +55,9 @@ public class LikeablePersonController {
 
         // 인스타인증을 했는지 체크
         if (instaMember != null) {
-            List<LikeablePerson> likeablePeople = likeablePersonService.findByFromInstaMemberId(instaMember.getId());
+            // 해당 인스타회원이 좋아하는 사람들 목록
+            List<LikeablePerson> likeablePeople = instaMember.getFromLikeablePeople();
+
             model.addAttribute("likeablePeople", likeablePeople);
         }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -62,7 +62,7 @@ public class LikeablePersonController {
     }
 
     @GetMapping("/delete/{id}")
-    public String delete(@PathVariable("id") Integer id) {
+    public String delete(@PathVariable("id") Long id) {
 
         LikeablePerson likeablePerson = likeablePersonService.getLikeablePerson(id);
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.List;
+import java.util.Objects;
 
 @Controller
 @RequestMapping("/likeablePerson")
@@ -67,16 +68,18 @@ public class LikeablePersonController {
 
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/delete/{id}")
-    public String delete(@PathVariable("id") Long id) {
+    public String delete(@PathVariable Long id) {
+        LikeablePerson likeablePerson = likeablePersonService.findById(id).orElse(null);
 
-        LikeablePerson likeablePerson = likeablePersonService.getLikeablePerson(id);
+        if (likeablePerson == null) return rq.historyBack("이미 삭제된 호감입니다.");
 
-        if (!rq.getMember().getInstaMember().getId().equals(likeablePerson.getFromInstaMember().getId())) {
+        if (!Objects.equals(rq.getMember().getInstaMember().getId(), likeablePerson.getFromInstaMember().getId()))
             return rq.historyBack("삭제 권한이 없습니다.");
-        }
 
-        likeablePersonService.delete(likeablePerson);
+        RsData deleteRs = likeablePersonService.delete(likeablePerson);
 
-        return rq.redirectWithMsg("/likeablePerson/list", "삭제 완료되었습니다.");
+        if (deleteRs.isFail()) return rq.historyBack(deleteRs);
+
+        return rq.redirectWithMsg("/likeablePerson/list", deleteRs);
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.List;
-import java.util.Objects;
 
 @Controller
 @RequestMapping("/likeablePerson")
@@ -69,14 +68,7 @@ public class LikeablePersonController {
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/delete/{id}")
     public String delete(@PathVariable Long id) {
-        LikeablePerson likeablePerson = likeablePersonService.findById(id).orElse(null);
-
-        if (likeablePerson == null) return rq.historyBack("이미 삭제된 호감입니다.");
-
-        if (!Objects.equals(rq.getMember().getInstaMember().getId(), likeablePerson.getFromInstaMember().getId()))
-            return rq.historyBack("삭제 권한이 없습니다.");
-
-        RsData deleteRs = likeablePersonService.delete(likeablePerson);
+        RsData deleteRs = likeablePersonService.delete(rq.getMember(), id);
 
         if (deleteRs.isFail()) return rq.historyBack(deleteRs);
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,6 +26,7 @@ public class LikeablePersonController {
     private final Rq rq;
     private final LikeablePersonService likeablePersonService;
 
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/add")
     public String showAdd() {
         return "usr/likeablePerson/add";
@@ -37,6 +39,7 @@ public class LikeablePersonController {
         private final int attractiveTypeCode;
     }
 
+    @PreAuthorize("isAuthenticated()")
     @PostMapping("/add")
     public String add(@Valid AddForm addForm) {
         RsData<LikeablePerson> createRsData = likeablePersonService.like(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
@@ -48,6 +51,7 @@ public class LikeablePersonController {
         return rq.redirectWithMsg("/likeablePerson/list", createRsData);
     }
 
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/list")
     public String showList(Model model) {
         InstaMember instaMember = rq.getMember().getInstaMember();
@@ -61,6 +65,7 @@ public class LikeablePersonController {
         return "usr/likeablePerson/list";
     }
 
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/delete/{id}")
     public String delete(@PathVariable("id") Long id) {
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -68,9 +68,15 @@ public class LikeablePersonController {
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/delete/{id}")
     public String delete(@PathVariable Long id) {
-        RsData deleteRs = likeablePersonService.delete(rq.getMember(), id);
+        LikeablePerson likeablePerson = likeablePersonService.findById(id).orElse(null);
 
-        if (deleteRs.isFail()) return rq.historyBack(deleteRs);
+        RsData canActorDeleteRsData = likeablePersonService.canActorDelete(rq.getMember(), likeablePerson);
+
+        if (canActorDeleteRsData.isFail()) return rq.historyBack(canActorDeleteRsData);
+
+        RsData deleteRs = likeablePersonService.delete(likeablePerson);
+
+        if (deleteRs.isFail()) return rq.historyBack(deleteRs); // 삭제 실패 시
 
         return rq.redirectWithMsg("/likeablePerson/list", deleteRs);
     }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -58,5 +59,19 @@ public class LikeablePersonController {
         }
 
         return "usr/likeablePerson/list";
+    }
+
+    @GetMapping("/delete/{id}")
+    public String delete(@PathVariable("id") Integer id) {
+
+        LikeablePerson likeablePerson = likeablePersonService.getLikeablePerson(id);
+
+        if (!rq.getMember().getInstaMember().getId().equals(likeablePerson.getFromInstaMember().getId())) {
+            return rq.historyBack("삭제 권한이 없습니다.");
+        }
+
+        likeablePersonService.delete(likeablePerson);
+
+        return rq.redirectWithMsg("/likeablePerson/list", "삭제 완료되었습니다.");
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
@@ -30,9 +30,11 @@ public class LikeablePerson {
     @ManyToOne
     private InstaMember fromInstaMember; // 호감을 표시한 사람(인스타 멤버)
     private String fromInstaMemberUsername; // 혹시 몰라서 기록
+
     @ManyToOne
     private InstaMember toInstaMember; // 호감을 받은 사람(인스타 멤버)
     private String toInstaMemberUsername; // 혹시 몰라서 기록
+
     private int attractiveTypeCode; // 매력포인트(1=외모, 2=성격, 3=능력)
 
     public String getAttractiveTypeDisplayName() {

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
@@ -28,10 +28,12 @@ public class LikeablePerson {
     private LocalDateTime modifyDate;
 
     @ManyToOne
+    @ToString.Exclude // 양방향을 걸면, 여기에 달아주는게 보통이다. 이렇게 해야 무한재귀가 실행되지 않는다.
     private InstaMember fromInstaMember; // 호감을 표시한 사람(인스타 멤버)
     private String fromInstaMemberUsername; // 혹시 몰라서 기록
 
     @ManyToOne
+    @ToString.Exclude // 양방향을 걸면, 여기에 달아주는게 보통이다. 이렇게 해야 무한재귀가 실행되지 않는다.
     private InstaMember toInstaMember; // 호감을 받은 사람(인스타 멤버)
     private String toInstaMemberUsername; // 혹시 몰라서 기록
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Integer> {
+public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Long> {
     List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -33,11 +33,12 @@ public class LikeablePersonService {
             return RsData.of("F-1", "본인을 호감상대로 등록할 수 없습니다.");
         }
 
+        InstaMember fromInstaMember = member.getInstaMember();
         InstaMember toInstaMember = instaMemberService.findByUsernameOrCreate(username).getData();
 
         LikeablePerson likeablePerson = LikeablePerson
                 .builder()
-                .fromInstaMember(member.getInstaMember()) // 호감을 표시하는 사람의 인스타 멤버
+                .fromInstaMember(fromInstaMember) // 호감을 표시하는 사람의 인스타 멤버
                 .fromInstaMemberUsername(member.getInstaMember().getUsername()) // 중요하지 않음
                 .toInstaMember(toInstaMember) // 호감을 받는 사람의 인스타 멤버
                 .toInstaMemberUsername(toInstaMember.getUsername()) // 중요하지 않음
@@ -45,6 +46,12 @@ public class LikeablePersonService {
                 .build();
 
         likeablePersonRepository.save(likeablePerson); // 저장
+
+        // 너가 좋아하는 호감표시 생겼어.
+        fromInstaMember.addFromLikeablePerson(likeablePerson);
+
+        // 너를 좋아하는 호감표시 생겼어.
+        toInstaMember.addToLikeablePerson(likeablePerson);
 
         return RsData.of("S-1", "입력하신 인스타유저(%s)를 호감상대로 등록되었습니다.".formatted(username), likeablePerson);
     }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Getter
@@ -57,7 +58,13 @@ public class LikeablePersonService {
     }
 
     @Transactional
-    public RsData delete(LikeablePerson likeablePerson) {
+    public RsData delete(Member actor, Long id) {
+        LikeablePerson likeablePerson = findById(id).orElse(null);
+
+        if (likeablePerson == null) return RsData.of("S-1", "이미 삭제된 호감입니다.");
+
+        if (!Objects.equals(actor.getInstaMember().getId(), likeablePerson.getFromInstaMember().getId()))
+            return RsData.of("S-2", "삭제 권한이 없습니다.");
 
         String toInstaMemberUsername = likeablePerson.getToInstaMember().getUsername();
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -6,12 +6,15 @@ import com.ll.gramgram.boundedContext.instaMember.service.InstaMemberService;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import com.ll.gramgram.boundedContext.likeablePerson.repository.LikeablePersonRepository;
 import com.ll.gramgram.boundedContext.member.entity.Member;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
+@Getter
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -47,5 +50,15 @@ public class LikeablePersonService {
 
     public List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId) {
         return likeablePersonRepository.findByFromInstaMemberId(fromInstaMemberId);
+    }
+
+    @Transactional
+    public void delete(LikeablePerson likeablePerson) {
+        likeablePersonRepository.delete(likeablePerson);
+    }
+
+    public LikeablePerson getLikeablePerson(Integer id) {
+        Optional<LikeablePerson> likeablePerson = likeablePersonRepository.findById(id);
+            return likeablePerson.get();
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -52,13 +52,17 @@ public class LikeablePersonService {
         return likeablePersonRepository.findByFromInstaMemberId(fromInstaMemberId);
     }
 
-    @Transactional
-    public void delete(LikeablePerson likeablePerson) {
-        likeablePersonRepository.delete(likeablePerson);
+    public Optional<LikeablePerson> findById(Long id) {
+        return likeablePersonRepository.findById(id);
     }
 
-    public LikeablePerson getLikeablePerson(Long id) {
-        Optional<LikeablePerson> likeablePerson = likeablePersonRepository.findById(id);
-            return likeablePerson.get();
+    @Transactional
+    public RsData delete(LikeablePerson likeablePerson) {
+
+        String toInstaMemberUsername = likeablePerson.getToInstaMember().getUsername();
+
+        likeablePersonRepository.delete(likeablePerson);
+
+        return RsData.of("S-1", "%s님에 대한 호감을 삭제하였습니다.".formatted(toInstaMemberUsername));
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -57,7 +57,7 @@ public class LikeablePersonService {
         likeablePersonRepository.delete(likeablePerson);
     }
 
-    public LikeablePerson getLikeablePerson(Integer id) {
+    public LikeablePerson getLikeablePerson(Long id) {
         Optional<LikeablePerson> likeablePerson = likeablePersonRepository.findById(id);
             return likeablePerson.get();
     }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -58,18 +58,19 @@ public class LikeablePersonService {
     }
 
     @Transactional
-    public RsData delete(Member actor, Long id) {
-        LikeablePerson likeablePerson = findById(id).orElse(null);
-
-        if (likeablePerson == null) return RsData.of("S-1", "이미 삭제된 호감입니다.");
-
-        if (!Objects.equals(actor.getInstaMember().getId(), likeablePerson.getFromInstaMember().getId()))
-            return RsData.of("S-2", "삭제 권한이 없습니다.");
-
+    public RsData delete(LikeablePerson likeablePerson) {
         String toInstaMemberUsername = likeablePerson.getToInstaMember().getUsername();
-
         likeablePersonRepository.delete(likeablePerson);
 
-        return RsData.of("S-1", "%s님에 대한 호감을 삭제하였습니다.".formatted(toInstaMemberUsername));
+        return RsData.of("S-1", "%s님에 대한 호감을 취소하였습니다.".formatted(toInstaMemberUsername));
+    }
+
+    public RsData canActorDelete(Member actor, LikeablePerson likeablePerson) {
+        if (likeablePerson == null) return RsData.of("F-1", "이미 삭제되었습니다.");
+
+        if (!Objects.equals(actor.getInstaMember().getId(), likeablePerson.getFromInstaMember().getId()))
+            return RsData.of("F-2", "권한이 없습니다.");
+
+        return RsData.of("S-1", "삭제가능합니다.");
     }
 }

--- a/src/main/resources/application-secret.yml.default
+++ b/src/main/resources/application-secret.yml.default
@@ -5,3 +5,6 @@ spring:
         registration:
           kakao:
             clientId: '카카오 클라이언트 ID'
+          google:
+            clientId: '구글 클라이언트 ID'
+            client-secret: '구글 클라이언트 시크릿'

--- a/src/main/resources/application-secret.yml.default
+++ b/src/main/resources/application-secret.yml.default
@@ -1,0 +1,7 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            clientId: '카카오 클라이언트 ID'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,8 +19,12 @@ spring:
             scope:
             client-name: Kakao
             authorization-grant-type: authorization_code
-            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            redirect-uri: '{baseUrl}/{action}/oauth2/code/{registrationId}'
             client-authentication-method: POST
+          google:
+            redirect-uri: '{baseUrl}/{action}/oauth2/code/{registrationId}'
+            client-name: Google
+            scope: profile
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,6 @@ spring:
       client:
         registration:
           kakao:
-            clientId: '카카오 클라이언트 ID'
             scope:
             client-name: Kakao
             authorization-grant-type: authorization_code

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,44 @@
+spring:
+  mvc:
+    hiddenmethod:
+      filter:
+        enabled: true
+  profiles:
+    active: dev
+    include: secret
+  datasource:
+    driver-class-name: org.mariadb.jdbc.Driver
+    url: jdbc:mariadb://127.0.0.1:3306/gram__dev?useUnicode=true&characterEncoding=utf8&autoReconnect=true&serverTimezone=Asia/Seoul
+    username: root
+    password:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            clientId: '카카오 클라이언트 ID'
+            scope:
+            client-name: Kakao
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            client-authentication-method: POST
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+logging:
+  level:
+    root: INFO
+    com.ll.gramgram: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE
+    org.hibernate.orm.jdbc.extract: TRACE

--- a/src/main/resources/templates/usr/instaMember/connect.html
+++ b/src/main/resources/templates/usr/instaMember/connect.html
@@ -13,7 +13,7 @@
 
             form.username.value = form.username.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
 
-            if (form.username.value.length == 0) {
+            if (form.username.value.length === 0) {
                 toastWarning('인스타그램 아이디를 입력해주세요.');
                 form.username.focus();
                 return;
@@ -27,7 +27,7 @@
 
             const $checkedGenderRadioButton = $(form).find("[name=gender]:checked");
 
-            if ($checkedGenderRadioButton.length == 0) {
+            if ($checkedGenderRadioButton.length === 0) {
                 toastWarning('성별을 선택해주세요.');
                 $(form).find("[name=gender]:first").focus();
                 return;

--- a/src/main/resources/templates/usr/layout/layout.html
+++ b/src/main/resources/templates/usr/layout/layout.html
@@ -39,7 +39,8 @@
     <a href="/likeablePerson/list" th:if="${@rq.login}" class="btn btn-link">호감목록</a>
     <a href="javascript:;" th:if="${@rq.login}" onclick="$(this).next().submit();" class="btn btn-link">로그아웃</a>
     <form th:if="${@rq.login}" hidden th:action="|/member/logout|" method="POST"></form>
-    <span th:if="${@rq.login}" th:text="|${@rq.member.username}님 환영합니다.(${#lists.size(@rq.member.instaMember.toLikeablePeople)}/${#lists.size(@rq.member.instaMember.fromLikeablePeople)})|"></span>
+    <span th:if="${@rq.login}" th:text="|${@rq.member.username}님 환영합니다.|"></span>
+    <span th:if="${@rq.login and @rq.member.hasConnectedInstaMember()}" th:text="|(${#lists.size(@rq.member.instaMember.toLikeablePeople)}/${#lists.size(@rq.member.instaMember.fromLikeablePeople)})|"></span>
 </header>
 
 <main layout:fragment="main"></main>

--- a/src/main/resources/templates/usr/layout/layout.html
+++ b/src/main/resources/templates/usr/layout/layout.html
@@ -39,7 +39,7 @@
     <a href="/likeablePerson/list" th:if="${@rq.login}" class="btn btn-link">호감목록</a>
     <a href="javascript:;" th:if="${@rq.login}" onclick="$(this).next().submit();" class="btn btn-link">로그아웃</a>
     <form th:if="${@rq.login}" hidden th:action="|/member/logout|" method="POST"></form>
-    <span th:if="${@rq.login}" th:text="|${@rq.member.username}님 환영합니다.|"></span>
+    <span th:if="${@rq.login}" th:text="|${@rq.member.username}님 환영합니다.(${#lists.size(@rq.member.instaMember.fromLikeablePeople)})|"></span>
 </header>
 
 <main layout:fragment="main"></main>

--- a/src/main/resources/templates/usr/layout/layout.html
+++ b/src/main/resources/templates/usr/layout/layout.html
@@ -39,7 +39,7 @@
     <a href="/likeablePerson/list" th:if="${@rq.login}" class="btn btn-link">호감목록</a>
     <a href="javascript:;" th:if="${@rq.login}" onclick="$(this).next().submit();" class="btn btn-link">로그아웃</a>
     <form th:if="${@rq.login}" hidden th:action="|/member/logout|" method="POST"></form>
-    <span th:if="${@rq.login}" th:text="|${@rq.member.username}님 환영합니다.(${#lists.size(@rq.member.instaMember.fromLikeablePeople)})|"></span>
+    <span th:if="${@rq.login}" th:text="|${@rq.member.username}님 환영합니다.(${#lists.size(@rq.member.instaMember.toLikeablePeople)}/${#lists.size(@rq.member.instaMember.fromLikeablePeople)})|"></span>
 </header>
 
 <main layout:fragment="main"></main>

--- a/src/main/resources/templates/usr/likeablePerson/add.html
+++ b/src/main/resources/templates/usr/likeablePerson/add.html
@@ -6,7 +6,7 @@
 
 <body>
 
-<mai layout:fragment="main">
+<main layout:fragment="main">
     <th:block th:unless="${@rq.member.hasConnectedInstaMember}">
         <div>먼저 본인의 인스타그램 아이디를 입력해주세요.</div>
 
@@ -24,7 +24,7 @@
 
                 form.username.value = form.username.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
 
-                if (form.username.value.length == 0) {
+                if (form.username.value.length === 0) {
                     toastWarning('상대방의 인스타그램 아이디를 입력해주세요.');
                     form.username.focus();
                     return;
@@ -36,7 +36,7 @@
                     return;
                 }
 
-                if (form.username.value == myInstaMember.username) {
+                if (form.username.value === myInstaMember.username) {
                     toastWarning('본인을 호감상대로 등록할 수 없습니다.');
                     form.username.focus();
                     return;
@@ -44,7 +44,7 @@
 
                 const $checkedAttractiveTypeCodeRadioButton = $(form).find("[name=attractiveTypeCode]:checked");
 
-                if ($checkedAttractiveTypeCodeRadioButton.length == 0) {
+                if ($checkedAttractiveTypeCodeRadioButton.length === 0) {
                     toastWarning('상대방의 매력포인트를 선택해주세요.');
                     $(form).find("[name=attractiveTypeCode]:first").focus();
                     return;
@@ -88,7 +88,7 @@
             </div>
         </form>
     </th:block>
-</mai>
+</main>
 </body>
 
 </html>

--- a/src/main/resources/templates/usr/likeablePerson/list.html
+++ b/src/main/resources/templates/usr/likeablePerson/list.html
@@ -6,7 +6,7 @@
 
 <body>
 
-<mai layout:fragment="main">
+<main layout:fragment="main">
     <th:block th:unless="${@rq.member.hasConnectedInstaMember}">
         <div>먼저 본인의 인스타그램 아이디를 입력해주세요.</div>
 
@@ -25,7 +25,7 @@
             </li>
         </ul>
     </th:block>
-</mai>
+</main>
 </body>
 
 </html>

--- a/src/main/resources/templates/usr/likeablePerson/list.html
+++ b/src/main/resources/templates/usr/likeablePerson/list.html
@@ -21,7 +21,7 @@
                 <span class="toInstaMember_username" th:text="${likeablePerson.toInstaMember.username}"></span>
                 <span class="toInstaMember_attractiveTypeDisplayName"
                       th:text="${likeablePerson.attractiveTypeDisplayName}"></span>
-                <a th:href="@{|delete/${likeablePerson.id}|}" onclick="return confirm('정말로 삭제하시겠습니까?');">삭제</a>
+                <a class="btn btn-primary m-2" th:href="@{|delete/${likeablePerson.id}|}" onclick="return confirm('정말로 삭제하시겠습니까?');" role="button">삭제</a>
             </li>
         </ul>
     </th:block>

--- a/src/main/resources/templates/usr/likeablePerson/list.html
+++ b/src/main/resources/templates/usr/likeablePerson/list.html
@@ -21,7 +21,8 @@
                 <span class="toInstaMember_username" th:text="${likeablePerson.toInstaMember.username}"></span>
                 <span class="toInstaMember_attractiveTypeDisplayName"
                       th:text="${likeablePerson.attractiveTypeDisplayName}"></span>
-                <a class="btn btn-primary m-2" th:href="@{|delete/${likeablePerson.id}|}" onclick="return confirm('정말로 삭제하시겠습니까?');" role="button">삭제</a>
+                <a class="btn btn-primary m-2" href="javascript:;" onclick="if ( confirm('정말로 삭제하시겠습니까?') ) $(this).next().submit();" role="button">삭제</a>
+                <form hidden th:action="@{|delete/${likeablePerson.id}|}" method="POST"></form>
             </li>
         </ul>
     </th:block>

--- a/src/main/resources/templates/usr/likeablePerson/list.html
+++ b/src/main/resources/templates/usr/likeablePerson/list.html
@@ -22,7 +22,9 @@
                 <span class="toInstaMember_attractiveTypeDisplayName"
                       th:text="${likeablePerson.attractiveTypeDisplayName}"></span>
                 <a class="btn btn-primary m-2" href="javascript:;" onclick="if ( confirm('정말로 삭제하시겠습니까?') ) $(this).next().submit();" role="button">삭제</a>
-                <form hidden th:action="@{|delete/${likeablePerson.id}|}" method="POST"></form>
+                <form hidden th:action="@{|/likeablePerson/${likeablePerson.id}|}" method="POST">
+                    <input type="hidden" name="_method" value="delete">
+                </form>
             </li>
         </ul>
     </th:block>

--- a/src/main/resources/templates/usr/member/join.html
+++ b/src/main/resources/templates/usr/member/join.html
@@ -13,7 +13,7 @@
 
             form.username.value = form.username.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
 
-            if (form.username.value.length == 0) {
+            if (form.username.value.length === 0) {
                 toastWarning('아이디를 입력해주세요.');
                 form.username.focus();
                 return;
@@ -29,7 +29,7 @@
 
             form.password.value = form.password.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
 
-            if (form.password.value.length == 0) {
+            if (form.password.value.length === 0) {
                 form.password.focus();
                 toastWarning('비밀번호를 입력해주세요.');
                 return;

--- a/src/main/resources/templates/usr/member/login.html
+++ b/src/main/resources/templates/usr/member/login.html
@@ -13,7 +13,7 @@
 
             form.username.value = form.username.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
 
-            if (form.username.value.length == 0) {
+            if (form.username.value.length === 0) {
                 toastWarning('아이디를 입력해주세요.');
                 form.username.focus();
                 return;
@@ -29,7 +29,7 @@
 
             form.password.value = form.password.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
 
-            if (form.password.value.length == 0) {
+            if (form.password.value.length === 0) {
                 form.password.focus();
                 toastWarning('비밀번호를 입력해주세요.');
                 return;

--- a/src/main/resources/templates/usr/member/login.html
+++ b/src/main/resources/templates/usr/member/login.html
@@ -63,7 +63,7 @@
         </a>
 
         <a class="btn btn-link" href="/oauth2/authorization/google">
-            구글 로그인하기(아직 안됨)
+            구글 로그인하기
         </a>
 
         <a class="btn btn-link" href="/oauth2/authorization/naver">

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -16,8 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -161,7 +160,7 @@ public class LikeablePersonControllerTests {
         // WHEN
         ResultActions resultActions = mvc
                 .perform(
-                        post("/likeablePerson/delete/1")
+                        delete("/likeablePerson/1")
                                 .with(csrf())
                 )
                 .andDo(print());

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -160,7 +160,10 @@ public class LikeablePersonControllerTests {
     void t006() throws Exception {
         // WHEN
         ResultActions resultActions = mvc
-                .perform(get("/likeablePerson/delete/1"))
+                .perform(
+                        post("/likeablePerson/delete/1")
+                                .with(csrf())
+                )
                 .andDo(print());
 
         // THEN

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -1,6 +1,7 @@
 package com.ll.gramgram.boundedContext.likeablePerson.controller;
 
 
+import com.ll.gramgram.boundedContext.likeablePerson.service.LikeablePersonService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +13,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -26,6 +28,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class LikeablePersonControllerTests {
     @Autowired
     private MockMvc mvc;
+    @Autowired
+    private LikeablePersonService likeablePersonService;
 
     @Test
     @DisplayName("등록 폼(인스타 인증을 안해서 폼 대신 메세지)")
@@ -166,5 +170,8 @@ public class LikeablePersonControllerTests {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("/likeablePerson/list**"))
         ;
+
+        // 삭제완료 후 id기 1번인 호감은 존재하지 않아야 한다
+        assertThat(likeablePersonService.findById(1L).isPresent()).isEqualTo(false);
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -149,4 +149,22 @@ public class LikeablePersonControllerTests {
                         """.stripIndent().trim())));
         ;
     }
+
+    @Test
+    @DisplayName("호감삭제")
+    @WithUserDetails("user3") // NotProd 에 생성된 초기데이터
+    void t006() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(get("/likeablePerson/delete/1"))
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("delete"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("/likeablePerson/list**"))
+        ;
+    }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -176,4 +176,46 @@ public class LikeablePersonControllerTests {
         // 삭제완료 후 id가 1번인 호감은 존재하지 않아야 한다
         assertThat(likeablePersonService.findById(1L).isPresent()).isEqualTo(false);
     }
+
+    @Test
+    @DisplayName("호감삭제(없는거 삭제, 삭제가 안되어야 함)")
+    @WithUserDetails("user3")
+    void t007() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(
+                        delete("/likeablePerson/100")
+                                .with(csrf())
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("delete"))
+                .andExpect(status().is4xxClientError())
+        ;
+    }
+
+    @Test
+    @DisplayName("호감삭제(권한이 없는 경우, 삭제가 안됨)")
+    @WithUserDetails("user2")
+    void t008() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(
+                        delete("/likeablePerson/1")
+                                .with(csrf())
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("delete"))
+                .andExpect(status().is4xxClientError())
+        ;
+
+        assertThat(likeablePersonService.findById(1L).isPresent()).isEqualTo(true);
+    }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -171,7 +171,7 @@ public class LikeablePersonControllerTests {
                 .andExpect(redirectedUrlPattern("/likeablePerson/list**"))
         ;
 
-        // 삭제완료 후 id기 1번인 호감은 존재하지 않아야 한다
+        // 삭제완료 후 id가 1번인 호감은 존재하지 않아야 한다
         assertThat(likeablePersonService.findById(1L).isPresent()).isEqualTo(false);
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/member/controller/MemberControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/member/controller/MemberControllerTests.java
@@ -1,11 +1,5 @@
 package com.ll.gramgram.boundedContext.member.controller;
 
-
-import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
-import com.ll.gramgram.boundedContext.instaMember.service.InstaMemberService;
-import com.ll.gramgram.boundedContext.likeablePerson.controller.LikeablePersonController;
-import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
-import com.ll.gramgram.boundedContext.likeablePerson.service.LikeablePersonService;
 import com.ll.gramgram.boundedContext.member.entity.Member;
 import com.ll.gramgram.boundedContext.member.service.MemberService;
 import jakarta.servlet.http.HttpSession;
@@ -22,8 +16,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -42,8 +34,6 @@ public class MemberControllerTests {
     private MockMvc mvc;
     @Autowired
     private MemberService memberService;
-    @Autowired
-    private LikeablePersonService likeablePersonService;
 
     @Test
     @DisplayName("회원가입 폼")
@@ -226,34 +216,5 @@ public class MemberControllerTests {
                 .andExpect(content().string(containsString("""
                         user1님 환영합니다.
                         """.stripIndent().trim())));
-    }
-
-    @Test
-    @DisplayName("호감상대 추가")
-    @WithUserDetails("user1")
-    void t007() throws Exception {
-
-        Member member = memberService.findByUsername("user1").orElse(null);
-        assert member != null;
-        List<LikeablePerson> likeablePersonList = likeablePersonService.findByFromInstaMemberId(member.getInstaMember().getId());
-        int sizeBeforeAdd = likeablePersonList.size();
-
-        // WHEN
-        ResultActions resultActions = mvc
-                .perform(post("/likeablePerson/add/")
-                        .param("fromInstaMember", "member")
-                        .param("toInstaMemberUsername", "dowon")
-                        .param("attractiveTypeCode", "1")
-                )
-                .andDo(print()); // 크게 의미 없고, 그냥 확인용
-
-        // THEN
-        resultActions
-                .andExpect(handler().handlerType(LikeablePersonController.class))
-                .andExpect(handler().methodName("add"))
-                .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrlPattern("/likeablePerson/list?msg=**"));
-
-        assertThat(likeablePersonList.size()).isEqualTo(sizeBeforeAdd + 1);
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/member/controller/MemberControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/member/controller/MemberControllerTests.java
@@ -1,6 +1,11 @@
 package com.ll.gramgram.boundedContext.member.controller;
 
 
+import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
+import com.ll.gramgram.boundedContext.instaMember.service.InstaMemberService;
+import com.ll.gramgram.boundedContext.likeablePerson.controller.LikeablePersonController;
+import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
+import com.ll.gramgram.boundedContext.likeablePerson.service.LikeablePersonService;
 import com.ll.gramgram.boundedContext.member.entity.Member;
 import com.ll.gramgram.boundedContext.member.service.MemberService;
 import jakarta.servlet.http.HttpSession;
@@ -17,6 +22,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -35,6 +42,8 @@ public class MemberControllerTests {
     private MockMvc mvc;
     @Autowired
     private MemberService memberService;
+    @Autowired
+    private LikeablePersonService likeablePersonService;
 
     @Test
     @DisplayName("회원가입 폼")
@@ -217,5 +226,34 @@ public class MemberControllerTests {
                 .andExpect(content().string(containsString("""
                         user1님 환영합니다.
                         """.stripIndent().trim())));
+    }
+
+    @Test
+    @DisplayName("호감상대 추가")
+    @WithUserDetails("user1")
+    void t007() throws Exception {
+
+        Member member = memberService.findByUsername("user1").orElse(null);
+        assert member != null;
+        List<LikeablePerson> likeablePersonList = likeablePersonService.findByFromInstaMemberId(member.getInstaMember().getId());
+        int sizeBeforeAdd = likeablePersonList.size();
+
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(post("/likeablePerson/add/")
+                        .param("fromInstaMember", "member")
+                        .param("toInstaMemberUsername", "dowon")
+                        .param("attractiveTypeCode", "1")
+                )
+                .andDo(print()); // 크게 의미 없고, 그냥 확인용
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("add"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("/likeablePerson/list?msg=**"));
+
+        assertThat(likeablePersonList.size()).isEqualTo(sizeBeforeAdd + 1);
     }
 }


### PR DESCRIPTION
## Title: [1Week] 김도원

### 미션 요구사항 분석 & 체크리스트

---
- [x] 호감상대 삭제 기능 구현
    - [x] url의 `[likeablePerson.id](http://likeablePerson.id)` 와 일치하는 데이터를 DB에서 삭제
    - [x] 삭제 권한 체크 (본인이 등록한 호감상대만 삭제 가능)
    - [x] 삭제 후 다시 호감목록 페이지로 이동 (rq.redirectWithMsg 함수 사용)
    - [x] 삭제 버튼 style 적용

- [ ] 테스트케이스 작성
    - [ ] 호감상대 추가
    - [ ] 호감상대 삭제


### 1주차 미션 요약

---

**[접근 방법]**

- `호감상대 삭제 = DB에서 LikeablePerson 테이블의 row 하나를 삭제하는 것` 에 중점을 두고 구현하였습니다.
- 미션 진행하기 전 실습했던 <점프 투 스프링부트> 책과 gramgram 프로젝트를 참고하였습니다.

- 목표: 삭제권한 체크 후 삭제처리 & 확인창 보여주기

1. 호감상대 삭제 기능 구현
- @GetMapping 어노테이션을 사용하여 LikeablePersonController의 delete() 메서드를 list.html에서 요청된 URL과 매핑
- 요청된 URL에서 `[likeablePerson.id](http://likeablePerson.id)` 는 Controller의 매개변수로 받을 때 likeablePerson. 없이 id만 작성해야 함
    - 그렇지 않으면 오류발생
- 매개변수 id와 일치하는 likeablePerson 객체 가져오기
    - 객체를 쉽게 가져오기 위해 `likeablePersonService에 getLikeablePerson()` 메서드 구현
- rq의 getMember() 메서드를 사용하여 현재 로그인한 Member의 객체를 가져와서 likeablePerson 객체 안의 FromInstaMember의 id와 일치하는지 확인하기
- `rq.redirectWithMsg()`를 활용하여 메세지 출력하고 호감목록으로 이동하기


2. 테스트케이스 작성
- MockMvc 클래스와 resultActions 클래스 등을 다루는 것이 어려워 미완료



**[특이사항]**

- 삭제 권한 체크하는 코드에서 if문의 조건식을 잘못 작성하였을 때, 호감표시와 호감목록에 접속이 안되는 오류가 발생하였습니다.
    - 호감표시와 관련된 코드가 없는데 왜 호감표시까지 오류발생하는지 궁금합니다.

**Refactoring**
- 삭제 완료 후 뜨는 확인창 표시시간 줄이기